### PR TITLE
[master] Correct partitions paths for dm-verity configs

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -162,7 +162,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.wifi.addr_path=/data/misc/wifi/wlan_mac.bin
 
 # setup dm-verity configs.
-PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc.0/c0c4000.sdhci/by-name/system
-PRODUCT_VENDOR_VERITY_PARTITION := /dev/block/platform/soc.0/c0c4000.sdhci/by-name/vendor
+PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/c0c4000.sdhci/by-name/system
+PRODUCT_VENDOR_VERITY_PARTITION := /dev/block/platform/soc/c0c4000.sdhci/by-name/vendor
 $(call inherit-product, build/target/product/verity.mk)
 


### PR DESCRIPTION
'soc.0' path has been replaced with 'soc' since k3.18.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>