### PR TITLE
Remove vbmeta from A/B partitions list

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -30,8 +30,7 @@ AB_OTA_UPDATER := true
 
 AB_OTA_PARTITIONS += \
     boot \
-    system \
-    vbmeta
+    system
 
 # Audio
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
* Fixes generating OTA packages:
  AssertionError: cannot find vbmeta.img