### PR TITLE
audio: update low latency record pcm

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -49,8 +49,8 @@
         <usecase name="USECASE_AUDIO_SPKR_CALIB_TX" type="in" id="40"/>
         <usecase name="USECASE_AUDIO_PLAYBACK_AFE_PROXY" type="out" id="6"/>
         <usecase name="USECASE_AUDIO_RECORD_AFE_PROXY" type="in" id="7"/>
-        <usecase name="USECASE_AUDIO_RECORD_LOW_LATENCY" type="in" id="17" />
-        <usecase name="USECASE_AUDIO_PLAYBACK_ULL" type="out" id="17" />
+        <usecase name="USECASE_AUDIO_RECORD_LOW_LATENCY" type="in" id="13" />
+        <!--<usecase name="USECASE_AUDIO_PLAYBACK_ULL" type="out" id="17" />-->
         <usecase name="USECASE_AUDIO_PLAYBACK_EXT_DISP_SILENCE" type="out" id="27" />
         <usecase name="USECASE_AUDIO_HFP_SCO" type="in" id="12" />
         <usecase name="USECASE_AUDIO_HFP_SCO_WB" type="in" id="12" />


### PR DESCRIPTION
we don't use NOIRQ which makes pcm fails and then not audio on specific audio usecases

Signed-off-by: David Viteri <davidteri91@gmail.com>