### PR TITLE
nile: add guard to serial console

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -42,7 +42,9 @@ BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += display_status=on
 
 # Serial console
-#BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0xc170000 androidboot.console=msm_serial_dm,0xc170000
+ifeq ($(BOARD_ENABLE_SERIAL_CONSOLE),true)
+BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0xc170000 androidboot.console=msm_serial_dm,0xc170000
+endif
 
 TARGET_RECOVERY_WIPE := $(PLATFORM_COMMON_PATH)/rootdir/recovery.wipe
 TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.nile


### PR DESCRIPTION
enable it by a flag when is needed

Signed-off-by: David Viteri <davidteri91@gmail.com>