### PR TITLE
[master] Remove deprecated paths

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -145,13 +145,6 @@
 
 # NFC
 /dev/pn54x                                             0660 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  recv_rsp    0600 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  send_cmd    0200 nfc nfc
-
-# NFC - k4.9
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc
@@ -159,17 +152,6 @@
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  send_cmd    0200 nfc nfc
 
 # LED
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* brightness     0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* blink          0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* duty_pcts      0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/rgb   rgb_blink      0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  brightness     0664 system system
-/sys/class/leds/lcd-backlight max_brightness                                                                                0644 root system
-/sys/class/leds/lcd-backlight brightness                                                                                    0664 system system
-
-# LED - k4.9
 /sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
 /sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* brightness     0664 system system
 /sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* blink          0664 system system

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,35 +1,4 @@
-genfscon sysfs /bus/esoc/devices                                        u:object_r:sysfs_msm_subsys:s0
-
-genfscon sysfs /devices/soc/c175000.i2c                                 u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/c176000.i2c                                 u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/c1b6000.i2c                                 u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/5000000.qcom,kgsl-3d0                       u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/15700000.qcom,lpass                         u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/c900000.qcom,mdss_mdp                       u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/c900000.qcom,mdss_rotator                   u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/4080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/800f000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/cce0000.qcom,venus                          u:object_r:sysfs_msm_subsys:s0
-
-genfscon sysfs /devices/soc/ca0c000.qcom,cci                            u:object_r:sysfs_camera:s0
-genfscon sysfs /devices/soc/ca1c000.qcom,jpeg                           u:object_r:sysfs_camera:s0
-genfscon sysfs /devices/soc/caa0000.qcom,jpeg                           u:object_r:sysfs_camera:s0
-genfscon sysfs /devices/soc/ca00000.qcom,msm-cam                        u:object_r:sysfs_camera:s0
-
-genfscon sysfs /devices/soc/c900000.qcom,mdss_mdp/caps                  u:object_r:sysfs_mdss_mdp_caps:s0
-genfscon sysfs /devices/soc/85e00000.qcom,rmtfs_sharedmem               u:object_r:sysfs_rmtfs:s0
-
-genfscon sysfs /devices/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
-
-genfscon sysfs /devices/soc/c900000.qcom,mdss_mdp/c900000.qcom,mdss_mdp:qcom,mdss_fb_primary/leds                     u:object_r:sysfs_leds:s0
-genfscon sysfs /devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds     u:object_r:sysfs_leds:s0
-genfscon sysfs /devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d300/leds     u:object_r:sysfs_leds:s0
-genfscon sysfs /devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds     u:object_r:sysfs_leds:s0
-
-genfscon sysfs /devices/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qpnp,fg/power_supply/bms                        u:object_r:sysfs_batteryinfo:s0
-genfscon sysfs /devices/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qpnp,fg/power_supply/bms/capacity               u:object_r:sysfs_batteryinfo:s0
-genfscon sysfs /devices/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qcom,qpnp-smb2/power_supply/battery/capacity    u:object_r:sysfs_batteryinfo:s0
-
+genfscon sysfs /bus/esoc/devices                                                 u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/c175000.i2c                                 u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/c176000.i2c                                 u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
On kernel 4.9, /sys/devices/soc has been moved
to /sys/devices/platform/soc.

This branch for Android P+ and it uses kernel 4.9 only.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>