### PR TITLE
build update_engine_sideload needed for flash OTA packages

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -45,6 +45,7 @@ AB_OTA_POSTINSTALL_CONFIG += \
 PRODUCT_PACKAGES += \
     update_engine \
     update_engine_client \
+    update_engine_sideload \
     update_verifier \
     bootctrl.sdm660
 


### PR DESCRIPTION
E: can't run /sbin/update_engine_sideload (No such file or directory)

Signed-off-by: David Viteri <davidteri91@gmail.com>