### PR TITLE
label power_supply/parallel/type as sysfs_usb_supply

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -58,5 +58,6 @@ genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.q
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds     u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-01/800f000.qcom,spmi:qcom,pm660@1:qcom,haptic@c000/leds    u:object_r:sysfs_leds:s0
 
+genfscon sysfs /devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/(/.*)?                                                  u:object_r:sysfs_usb_supply:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qpnp,fg/power_supply                  u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-00/800f000.qcom,spmi:qcom,pm660@0:qcom,qpnp-smb2/power_supply           u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
following CAF to avoid denials in health

01-24 13:53:30.894   646   646 I healthd : type=1400 audit(0.0:3): avc: denied { read } for name=type dev=sysfs ino=39053 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1
01-24 13:53:30.894   646   646 I healthd : type=1400 audit(0.0:4): avc: denied { open } for path=/sys/devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/type dev=sysfs ino=39053 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1
01-24 13:53:30.894   646   646 I healthd : type=1400 audit(0.0:5): avc: denied { getattr } for path=/sys/devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/type dev=sysfs ino=39053 scontext=u:r:healthd:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>