### PR TITLE
[NILE] wifi: wpa_supplicant_overlay: Declare wowlan support

### DIFF
--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -3,3 +3,4 @@ p2p_disabled=1
 tdls_external_control=1
 hs20=1
 interworking=1
+wowlan_triggers=magic_pkt


### PR DESCRIPTION
Specify WoWLAN triggers to permit to keep the WiFi connected
while AP sleeps and the WLAN chip is in low power mode.
Resume the AP to handle special requests via a magic packet
sent from the WLAN chip.