### PR TITLE
label 18800000.qcom,icnss/net as sysfs_net

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -19,6 +19,8 @@ genfscon sysfs /devices/platform/soc/85e00000.qcom,rmtfs_sharedmem              
 
 genfscon sysfs /devices/platform/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
 
+genfscon sysfs /devices/platform/soc/18800000.qcom,icnss/net                     u:object_r:sysfs_net:s0
+
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_mdp/c900000.qcom,mdss_mdp:qcom,mdss_fb_primary/leds                     u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds     u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d300/leds     u:object_r:sysfs_leds:s0


### PR DESCRIPTION
following crosshatch and aosp sepolicy
https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r21/vendor/qcom/common/genfs_contexts#69
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/public/file.te#82
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/private/priv_app.te#90

avoid
12-12 20:03:11.079  4235  4235 I IntentService[D: type=1400 audit(0.0:101): avc: denied { open } for path=/sys/devices/platform/soc/18800000.qcom,icnss/net/p2p0/type dev=sysfs ino=63502 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>