### PR TITLE
sepolicy: label SDE path as sysfs_leds

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -22,6 +22,7 @@ genfscon sysfs /devices/platform/soc/soc:fpc1145                                
 genfscon sysfs /devices/platform/soc/18800000.qcom,icnss/net                     u:object_r:sysfs_net:s0
 
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_mdp/c900000.qcom,mdss_mdp:qcom,mdss_fb_primary/leds                     u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/platform/soc/c900000.qcom,sde_kms/backlight/panel0-backlight                                           u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds     u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d300/leds     u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds     u:object_r:sysfs_leds:s0


### PR DESCRIPTION
needed for Enforcing SELinux

discovery:/sys/class/backlight # ls -l
total 0
lrwxrwxrwx 1 root root 0 1970-05-10 03:18 panel0-backlight -> ../../devices/platform/soc/c900000.qcom,sde_kms/backlight/panel0-backlight

01-22 23:37:00.563   632   632 W light@2.0-servi: type=1400 audit(0.0:458): avc: denied { write } for name=brightness dev=sysfs ino=34255 scontext=u:r:hal_light_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>