### PR TITLE
[master] fstab.nile: Enable adoptable storage

### DIFF
--- a/rootdir/vendor/etc/fstab.nile
+++ b/rootdir/vendor/etc/fstab.nile
@@ -12,6 +12,6 @@
 /dev/block/bootdevice/by-name/bluetooth_a  /vendor/bt_firmware     vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 
-/devices/platform/soc/c084000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto
+/devices/platform/soc/c084000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                         voldmanaged=usb:auto
 /dev/block/zram0                            none        swap    defaults                                                      zramsize=1073741824,max_comp_streams=8


### PR DESCRIPTION
Based on https://github.com/sonyxperiadev/device-sony-yoshino/commit/59b75719fd133a9acb511f4e5b62fb719999573a