### PR TITLE
[Android 10] New-style bootctrl; bdroid_buildcfg hacks

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,3 @@
+soong_namespace {
+    imports: ["hardware/qcom/bootctrl"],
+}

--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -18,6 +18,12 @@
 #define _BDROID_BUILDCFG_H
 
 #if !defined(OS_GENERIC)
+#ifdef PROPERTY_VALUE_MAX
+#define PVAL_MAX_ALREADY_DEFINED
+#ifndef __CUTILS_PROPERTIES_H
+#undef PROPERTY_VALUE_MAX
+#endif
+#endif
 #include <cutils/properties.h>
 #include <string.h>
 
@@ -42,9 +48,12 @@ static inline const char* getBTDefaultName()
 }
 
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
-#endif // OS_GENERIC
 
+#ifndef PVAL_MAX_ALREADY_DEFINED
 #undef PROPERTY_VALUE_MAX
+#endif
+
+#endif // OS_GENERIC
 
 // Wide-band speech support
 #define BTM_WBS_INCLUDED TRUE

--- a/bootctrl/Android.bp
+++ b/bootctrl/Android.bp
@@ -1,0 +1,22 @@
+
+//
+// Copyright (C) 2018 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+cc_library {
+    name: "bootctrl.sdm660",
+    defaults: ["bootctrl_hal_defaults"],
+    static_libs: ["libgptutils"],
+}

--- a/platform.mk
+++ b/platform.mk
@@ -30,8 +30,6 @@ DEVICE_PACKAGE_OVERLAYS += \
 
 # A/B support
 AB_OTA_UPDATER := true
-TARGET_USES_HARDWARE_QCOM_BOOTCTRL := true
-
 PRODUCT_SHIPPING_API_LEVEL := 26
 
 # A/B OTA dexopt package
@@ -51,15 +49,8 @@ PRODUCT_PACKAGES += \
     update_engine_client \
     update_engine_sideload \
     update_verifier \
-    bootctrl.sdm660
-
-# Enable update engine sideloading by including the static version of the
-# boot_control HAL and its dependencies.
-PRODUCT_STATIC_BOOT_CONTROL_HAL := \
     bootctrl.sdm660 \
-    libgptutils \
-    libz \
-    libcutils
+    bootctrl.sdm660.recovery
 
 AB_OTA_PARTITIONS += \
     boot \


### PR DESCRIPTION
Welcome Nile on Android Q!

this converts the bootctrl hal to new-style BP with shared libraries, and uses soong_namespace (see relevant commit, also in common for an elaborate explanation).

`bdroid_buildcfg.h` is a bit of a mess, but will be can always clean this up after.