### PR TITLE
[Nile] [4/7] Enable FPC gestures

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate. -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- True if the device supports system navigation keys. -->
+    <bool name="config_supportSystemNavigationKeys">true</bool>
+</resources>

--- a/platform.mk
+++ b/platform.mk
@@ -91,6 +91,11 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/usr/keylayout/gpio-keys.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/gpio-keys.kl
 
+# FPC Gestures
+PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/vendor/usr/idc/uinput-fpc.idc:$(TARGET_COPY_OUT_VENDOR)/usr/idc/uinput-fpc.idc \
+    $(SONY_ROOT)/vendor/usr/keylayout/uinput-fpc.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/uinput-fpc.kl
+
 # MSM IRQ Balancer configuration file
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/msm_irqbalance.conf:$(TARGET_COPY_OUT_VENDOR)/etc/msm_irqbalance.conf

--- a/rootdir/vendor/usr/idc/uinput-fpc.idc
+++ b/rootdir/vendor/usr/idc/uinput-fpc.idc
@@ -1,0 +1,19 @@
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Fingerprint navigation configuration file
+#
+keyboard.orientationAware = 1
+keyboard.builtIn = 1

--- a/rootdir/vendor/usr/keylayout/uinput-fpc.kl
+++ b/rootdir/vendor/usr/keylayout/uinput-fpc.kl
@@ -1,0 +1,6 @@
+key 103   SYSTEM_NAVIGATION_UP
+key 108   SYSTEM_NAVIGATION_DOWN
+# Left and right are swapped, because this is a back-mounted sensor.
+# In other words, the sensor is mirrored relative to the screen.
+key 106   SYSTEM_NAVIGATION_LEFT
+key 105   SYSTEM_NAVIGATION_RIGHT


### PR DESCRIPTION
For https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/50

These config files are used to tie uinput events coming from `uinput-fpc` to semantic names that are understood by Android.