### PR TITLE
[NILE] WCNSS: Enable concurrent STA/AP on wlan1 interface.

### DIFF
--- a/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
+++ b/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
@@ -218,6 +218,9 @@ gEnableMCCMode=1
 #   without SAP restart by sending (E)CSA
 gWlanMccToSccSwitchMode = 0
 
+# Turn on STA + AP/STA
+gEnableConcurrentSTA=wlan1
+
 # 1=enable STBC; 0=disable STBC
 gEnableRXSTBC=1
 


### PR DESCRIPTION
Configure WCNSS to expose a secondary interface, wlan1, which is used
for concurrent AP while wlan0 runs the STA.