### PR TITLE
platform: Sync video props

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -199,6 +199,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.gralloc.disable_ubwc=1
 
+# SurfaceFlinger
+# Keep in sync with NUM_FRAMEBUFFER_SURFACE_BUFFERS
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.surface_flinger.max_frame_buffer_acquired_buffers=2
+
 # Display HACK: Use GPU composition only
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.display.primary_mixer_stages=1

--- a/platform.mk
+++ b/platform.mk
@@ -197,7 +197,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Disable UBWC
 PRODUCT_PROPERTY_OVERRIDES += \
-    video.disable.ubwc=1
+    vendor.gralloc.disable_ubwc=1
 
 # Display HACK: Use GPU composition only
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
The ConfigStore HAL is being deprecated and will apparently be removed in R.

See https://github.com/sonyxperiadev/device-sony-common/pull/709 for a more in-depths explanation.

Translate the uppercase makevars that `surfaceflinger.mk` used to supply as cflags to configstore internals to sysprops.

`max_frame_buffer_acquired_buffers = NUM_FRAMEBUFFER_SURFACE_BUFFER`

Note: The uppercase vars must be kept because `hardware/qcom/display` still relies on them at build time.