### PR TITLE
[VERIFYME] fstab: Split into early and latemount, reserve 128M on /data

### DIFF
--- a/rootdir/vendor/etc/fstab.nile
+++ b/rootdir/vendor/etc/fstab.nile
@@ -2,9 +2,9 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,recoveryonly,verify,slotselect
-/dev/block/bootdevice/by-name/vendor       /vendor      ext4    ro,barrier=1                                                  wait,recoveryonly,verify,slotselect
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,verify,slotselect,first_stage_mount
+/dev/block/bootdevice/by-name/vendor       /vendor      ext4    ro,barrier=1                                                  wait,verify,slotselect,first_stage_mount
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp_a        /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab.nile
+++ b/rootdir/vendor/etc/fstab.nile
@@ -4,7 +4,7 @@
 
 /dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,verify,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/vendor       /vendor      ext4    ro,barrier=1                                                  wait,verify,slotselect,first_stage_mount
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp_a        /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults


### PR DESCRIPTION
Makes things neater with the stage-separated mounting logic in Q and later.
