### PR TITLE
[NILE] vendor: WCNSS_qcom_cfg: Update configuration for new drivers

### DIFF
--- a/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
+++ b/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
@@ -216,7 +216,7 @@ gEnableMCCMode=1
 # 3-Force SCC if same band, without SAP restart by sending (E)CSA
 # 4-Force SCC if same band (or) use SAP mandatory channel for DBS,
 #   without SAP restart by sending (E)CSA
-gWlanMccToSccSwitchMode = 0
+gWlanMccToSccSwitchMode = 3
 
 # Turn on STA + AP/STA
 gEnableConcurrentSTA=wlan1
@@ -239,7 +239,7 @@ gEnableTxBFeeSAP=1
 # Enable Tx beamforming in VHT20MHz
 # Valid values are 0,1. If commented out, the default value is 0.
 # 0=disable, 1=enable
-gEnableTxBFin20MHz=0
+gEnableTxBFin20MHz=1
 
 #Enable/Disable SU Tx beamformer support.
 gEnableTxSUBeamformer=0
@@ -444,7 +444,7 @@ gCEClassifyEnable=1
 
 # Enable Rx handling options
 # Rx_thread=1 RPS=2(default for ROME) NAPI=4(default for ihelium)
-rx_mode=4
+rx_mode=5
 
 # Enable(Tx) fastpath for data traffic.
 # 1 - enable(default)  0 - disable
@@ -462,9 +462,9 @@ TSOEnable=1
 # 1 - enable  0 - disable
 gTcpAdvWinScaleEnable=0
 
-# Enable Large Recieve Offload
+# Enable Generic Receive Offload
 # 1 - enable(default)  0 - disable
-LROEnable=1
+GROEnable=1
 
 # Enable HT MPDU Density
 # 4 for 2 micro sec
@@ -476,13 +476,32 @@ ght_mpdu_density=4
 # 1 - enable 0 - disable(default)
 gEnableFlowSteering=1
 
+# Time in microseconds after which a NAPI poll must yield
+ce_service_max_yield_time=500
+
+#Maximum number of HTT messages to be processed per NAPI poll
+ce_service_max_rx_ind_flush=1
+
+# Maximum number of MSDUs the firmware will pack in one HTT_T2H_MSG_TYPE_RX_IN_ORD_PADDR_IND
+maxMSDUsPerRxInd=8
+
+# Enable NUD tracking feature
+# 1 - enable 0 - disable(default)
+gEnableNUDTracking=1
+
+# Enable PEER UNMAP CONF SUPPORT
+# 1 - enable 0 - disable(default)
+gEnablePeerUnmapConfSupport=1
+
 ################ Datapath feature set End ################
 
 ################ NAN feature set start ###################
 
 # Enable NAN discovery (NAN 1.0)
 # 1 - enable  0 - disable(default)
-gEnableNanSupport=0
+gEnableNanSupport=1
+# Enable NAN Datapath
+genable_nan_datapath=1
 ################ NAN feature set end #####################
 
 ################ Customize Listen Interval Begin ################
@@ -496,7 +515,28 @@ gMaxLIModulatedDTIM=6
 # 0 - REPORT_ACTUAL  1 - REPORT_MAX  2 - REPORT_MAX_SCALED
 gReportMaxLinkSpeed=0
 
+adaptive_dwell_mode_enabled=1
+
+hostscan_adaptive_dwell_mode=1
+
+adapt_dwell_lpf_weight=80
+
+adapt_dwell_wifi_act_threshold=10
+
+MAWCEnabled=0
+
+drop_bcn_on_chan_mismatch=0
+
+# Enable/Disable rtt sta mac randomization
+enable_rtt_mac_randomization=1
+
+#Enable/Disable SNR monitoring
+gEnableSNRMonitoring=1
+
+# Enable 5GHz to 2.4GHz Roam in SDM660 by overriding the default Value(40) with 0
+# With values ranging from 1 to 86, only 2.4GHz to 5GHz Roam works
+roam_bad_rssi_thresh_offset_2g=0
+
 END
 
 # Note: Configuration parser would not read anything past the END marker
-


### PR DESCRIPTION
Update the configuration for new drivers, including the
enablement of roaming between 5 and 2.4GHz networks (where
previously only 2.4GHz to 5GHz roaming was working, not vice
versa), monitor the network SNR for faster roaming decision,
adaptive dwell, enable Tx beamforming in VHT20MHz and others.


Needs testing on new wifi driver.