### PR TITLE
[NILE] Enable audio compr_voip feature

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -165,6 +165,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Audio - QCOM HAL
 PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.audio.feature.compr_voip.enable=true \
     vendor.audio.offload.buffer.size.kb=64
 
 ## sensor type


### PR DESCRIPTION
This feature is required because devices in this platform do not expose
an echo-reference-voip mixer path, where -voip is concatenated when this
feature is disabled. With this feature enabled echo-reference is
selected instead, which is available and solves broken voice calls in
certain apps.
