### PR TITLE
init.nile.pwr.rc: remove deprecated configs

### DIFF
--- a/rootdir/vendor/etc/init/init.nile.pwr.rc
+++ b/rootdir/vendor/etc/init/init.nile.pwr.rc
@@ -66,7 +66,6 @@ on boot
     # enable governor for power cluster
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay "19000 1344000:39000"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 85
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
@@ -74,14 +73,11 @@ on boot
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "85 1344000:80"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 39000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis 0
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 787200
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/ignore_hispeed_on_notif 0
 
     # enable governor for perf cluster
     write /sys/devices/system/cpu/cpu4/online 1
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "interactive"
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/use_migration_notif 1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/above_hispeed_delay "19000 1094400:39000"
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 85
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate 20000
@@ -89,9 +85,7 @@ on boot
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/io_is_busy 1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads "85 1094400:80"
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time 39000
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/max_freq_hysteresis 0
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 614400
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/ignore_hispeed_on_notif 0
 
     # re-enable thermal
     write /sys/module/msm_thermal/core_control/enabled 1


### PR DESCRIPTION
in the 4.14 kernel these configs are deprecated and should be removed to get rid of irrelevant errors in dmesg/logcat.