### PR TITLE
[master] Ueventd updates for 4.19 kernel

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -151,17 +151,28 @@ firmware_directories /vendor/firmware_mnt/image/
 # NFC
 /dev/pn553                                  0660 nfc nfc
 
-# LED
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* max_brightness 0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* brightness     0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* breath          0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* trigger      0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* delay_off       0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* delay_on       0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  max_brightness 0664 system system
-/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  brightness     0664 system system
-/sys/class/backlight/panel0-backlight max_brightness                                                                                  0644 root system
-/sys/class/backlight/panel0-backlight brightness                                                                                      0664 system system
+# LED class devices
+/sys/class/leds/red      max_brightness     0664 system    system
+/sys/class/leds/red      brightness         0664 system    system
+/sys/class/leds/red      breath             0664 system    system
+/sys/class/leds/red      trigger            0664 system    system
+/sys/class/leds/red      delay_off          0664 system    system
+/sys/class/leds/red      delay_on           0664 system    system
+/sys/class/leds/green    max_brightness     0664 system    system
+/sys/class/leds/green    brightness         0664 system    system
+/sys/class/leds/green    breath             0664 system    system
+/sys/class/leds/green    trigger            0664 system    system
+/sys/class/leds/green    delay_off          0664 system    system
+/sys/class/leds/green    delay_on           0664 system    system
+/sys/class/leds/blue     max_brightness     0664 system    system
+/sys/class/leds/blue     brightness         0664 system    system
+/sys/class/leds/blue     breath             0664 system    system
+/sys/class/leds/blue     trigger            0664 system    system
+/sys/class/leds/blue     delay_off          0664 system    system
+/sys/class/leds/blue     delay_on           0664 system    system
+
+/sys/class/backlight/panel0-backlight max_brightness    0644 root   system
+/sys/class/backlight/panel0-backlight brightness        0664 system system
 
 # Fingerprint sensor  device
 /dev/fingerprint         0664 system input

--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -150,11 +150,6 @@ firmware_directories /vendor/firmware_mnt/image/
 
 # NFC
 /dev/pn553                                  0660 nfc nfc
-/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
-/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
-/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc
-/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  recv_rsp    0600 nfc nfc
-/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  send_cmd    0200 nfc nfc
 
 # LED
 /sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/* max_brightness 0664 system system

--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -149,7 +149,7 @@ firmware_directories /vendor/firmware_mnt/image/
 /dev/ttyMSM0                                0660 bluetooth bluetooth
 
 # NFC
-/dev/pn54x                                             0660 nfc nfc
+/dev/pn553                                  0660 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
 /sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc


### PR DESCRIPTION
Contains:
1. Update NFC device name.
2. Remove obsolete NFC device permissions.
3. Update RGB LED sysfs path.